### PR TITLE
Add more aliases

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -20,20 +20,21 @@ const parserOptions = {
     aliases: {
         knight: ['night'],
         rook: [
-            'brooke', 'brooks', 'brook', 'work', 'route', 'rough', 'ruck',
-            'rupp', 'rupt', 'rocket', 'rock', 'rug'
+            'brooke', 'brooks', 'brookdale', 'brook', 'work', 'route', 'rough',
+            'trucks', 'truck', 'ruck', 'rupp', 'rupt', 'rocket', 'rockstar',
+            'rock', 'rugs', 'rug', 'look'
         ],
-        a: ['alpha'],
+        a: ['alpha', 'office', 'off of', 'also'],
         b: ['bravo', 'beta', 'beat', 'bee', 'be'],
         c: ['charlie', 'sea', 'see'],
         d: ['delta', 'the'],
         e: ['echo', 'eat'],
         f: ['foxtrot', 'at', 'of'],
         g: ['golf', 'gulf'],
-        h: ['hotel'],
+        h: ['hotel', 'stage', 'age', 'its', 'each'],
         2: ['too'],
-        4: ['force', 'for', 'far', 'park'],
-        5: ['v'],
+        4: ['force', 'for', 'far', 'park', 'store'],
+        5: ['v', 'psi'],
         6: ['sex'],
     }
 };

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -19,18 +19,22 @@ import MoveHistoryTable from './MoveHistoryTable';
 const parserOptions = {
     aliases: {
         knight: ['night'],
-        rook: ['brooke', 'brook'],
+        rook: [
+            'brooke', 'brook', 'work', 'route', 'rough', 'ruck', 'rupp', 'rupt',
+            'rock', 'rug'
+        ],
         a: ['alpha'],
-        b: ['bravo', 'bee', 'be'],
+        b: ['bravo', 'beta', 'beat', 'bee', 'be'],
         c: ['charlie', 'sea', 'see'],
-        d: ['delta'],
-        e: ['echo'],
-        f: ['foxtrot'],
-        g: ['golf'],
+        d: ['delta', 'the'],
+        e: ['echo', 'eat'],
+        f: ['foxtrot', 'at', 'of'],
+        g: ['golf', 'gulf'],
         h: ['hotel'],
         2: ['too'],
-        4: ['force', 'for'],
+        4: ['force', 'for', 'far', 'park'],
         5: ['v'],
+        6: ['sex'],
     }
 };
 

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -20,8 +20,8 @@ const parserOptions = {
     aliases: {
         knight: ['night'],
         rook: [
-            'brooke', 'brook', 'work', 'route', 'rough', 'ruck', 'rupp', 'rupt',
-            'rock', 'rug'
+            'brooke', 'brooks', 'brook', 'work', 'route', 'rough', 'ruck',
+            'rupp', 'rupt', 'rocket', 'rock', 'rug'
         ],
         a: ['alpha'],
         b: ['bravo', 'beta', 'beat', 'bee', 'be'],


### PR DESCRIPTION
Add more piece, rank, and file aliases based on real testing in Chrome. Chrome mistranscribes so many voice commands, especially with rooks, that I had to add a lot of random aliases.