### PR TITLE
Announce moves in natural language

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "speech-to-chess",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3340,9 +3340,9 @@
       }
     },
     "chess-nlp": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/chess-nlp/-/chess-nlp-1.4.0.tgz",
-      "integrity": "sha512-bFinsrHxhnr3YCXXrqHWk/scsQ6z8u3RPfg4oHXJ531IFLg+LTKbsGq2ZbEih2VK53vvKxpCUvSY1zVcGPcKnQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/chess-nlp/-/chess-nlp-1.5.0.tgz",
+      "integrity": "sha512-I6OwKFBRvgtUlIrOPO30AP++fEJov7jxPYQbgYQc6zdXwX9pTo6j9UcHC1CGErkVxk8FesdUjK7QEjiwtrNn6w==",
       "requires": {
         "pegjs": "^0.10.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "bootstrap": "^4.5.0",
-    "chess-nlp": "^1.4.0",
+    "chess-nlp": "^1.5.0",
     "jquery": "^3.5.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -45,21 +45,27 @@ const parser = new ChessNLP(parserOptions);
  * A chess game played with voice commands.
  */
 const App = (props) => {
-    const [status, setStatus] = useState();
+    const [status, setStatus] = useState({});
     const [waitingForVoiceCommand, setWaitingForVoiceCommand] = useState(false);
     const voiceCommandTimeout = useRef(null);
     const stopListeningRef = useRef(null);
 
     const handleLegalMove = (move) => {
-        setStatus(`Moved ${move}`);
+        const moveDesc = parser.sanToText(move);
+        setStatus({ display: `Moved ${move}`, announce: `Moved ${moveDesc}` });
     };
 
     const handleIllegalMove = (move) => {
-        setStatus(`Illegal move: ${move}`);
+        const moveDesc = parser.sanToText(move);
+        setStatus({
+            display: `Illegal move: ${move}`,
+            announce: `Illegal move: ${moveDesc}`
+        });
     };
 
     const handleGameOver = () => {
-        setStatus('Game over');
+        const status = 'Game over';
+        setStatus({ display: status, announce: status });
     };
 
     const { move: makeMove, undo, reset, history, fen } = useChess({
@@ -69,25 +75,29 @@ const App = (props) => {
     });
 
     const handleVoiceCommand = useCallback((command) => {
+        let status;
         setWaitingForVoiceCommand(false);
 
         switch (command) {
             case 'undo':
                 undo();
-                setStatus('Undid last move');
+                status = 'Undid last move';
+                setStatus({ display: status, announce: status });
                 return;
             case 'reset':
                 reset();
-                setStatus('Reset game');
+                status = 'Reset game';
+                setStatus({ display: status, announce: status });
                 return;
             default:
                 let move;
 
                 try {
-                    move = parser.toSAN(command);
+                    move = parser.textToSan(command);
                 }
                 catch (error) {
-                    setStatus(`I don't understand: ${command}`);
+                    status = `I don't understand: ${command}`;
+                    setStatus({ display: status, announce: status });
                     return;
                 }
 
@@ -160,7 +170,7 @@ const App = (props) => {
                     >
                         {listening ? 'Listening' : 'Click to give voice command'}
                     </Button>
-                    <GameStatus status={status} />
+                    <GameStatus {...status} />
                     <MoveHistoryTable moves={history} />
                 </Col>
             </Row>

--- a/frontend/src/components/App.spec.js
+++ b/frontend/src/components/App.spec.js
@@ -160,20 +160,21 @@ describe('App component', function() {
         it('should make a move when a valid voice command is given', function() {
             useSpeechRecognition.mockImplementation(({ onResult }) => ({
                 supported: true,
-                listen: jest.fn().mockImplementationOnce(() => onResult('e4'))
+                listen: jest.fn().mockImplementationOnce(() => onResult('Nf3'))
             }));
 
             useChess.mockImplementation(({ onLegalMove }) => ({
-                history: ['e4'],
+                history: ['Nf3'],
                 fen: 'foo',
-                move: jest.fn().mockImplementationOnce(() => onLegalMove('e4'))
+                move: jest.fn().mockImplementationOnce(() => onLegalMove('Nf3'))
             }));
 
             jest.isolateModules(() => {
                 jest.doMock('chess-nlp', () => ({
                     __esModule: true,
                     default: jest.fn(() => ({
-                        toSAN: text => 'e4'
+                        textToSan: text => 'Nf3',
+                        sanToText: san => 'knight to f3'
                     }))
                 }));
 
@@ -182,8 +183,13 @@ describe('App component', function() {
 
                 wrapper.find('.voice-command-button').simulate('click');
 
-                expect(wrapper).to.contain(<MoveHistoryTable moves={['e4']} />);
-                expect(wrapper).to.contain(<GameStatus status="Moved e4" />);
+                expect(wrapper).to.contain(<MoveHistoryTable moves={['Nf3']} />);
+                expect(wrapper).to.contain(
+                    <GameStatus
+                        display="Moved Nf3"
+                        announce="Moved knight to f3"
+                    />
+                );
                 expect(wrapper).to.containMatchingElement(
                     <Chessboard position="foo" />
                 );
@@ -207,7 +213,7 @@ describe('App component', function() {
                 jest.doMock('chess-nlp', () => ({
                     __esModule: true,
                     default: jest.fn(() => ({
-                        toSAN: text => { throw new Error('unparseable'); }
+                        textToSan: text => { throw new Error('unparseable'); }
                     }))
                 }));
 
@@ -218,7 +224,10 @@ describe('App component', function() {
 
                 expect(wrapper).to.contain(<MoveHistoryTable moves={[]} />);
                 expect(wrapper).to.contain(
-                    <GameStatus status="I don't understand: foo" />
+                    <GameStatus
+                        display="I don't understand: foo"
+                        announce="I don't understand: foo"
+                    />
                 );
                 expect(wrapper).to.containMatchingElement(
                     <Chessboard position="foo" />
@@ -246,7 +255,8 @@ describe('App component', function() {
                 jest.doMock('chess-nlp', () => ({
                     __esModule: true,
                     default: jest.fn(() => ({
-                        toSAN: text => 'Kh8'
+                        textToSan: text => 'Kh8',
+                        sanToText: san => 'king to h8'
                     }))
                 }));
 
@@ -257,8 +267,11 @@ describe('App component', function() {
 
                 expect(wrapper).to.contain(<MoveHistoryTable moves={[]} />);
                 expect(wrapper).to.contain(
-                    <GameStatus status="Illegal move: Kh8"
-                />);
+                    <GameStatus
+                        display="Illegal move: Kh8"
+                        announce="Illegal move: king to h8"
+                    />
+                );
                 expect(wrapper).to.containMatchingElement(
                     <Chessboard position="foo" />
                 );
@@ -284,7 +297,8 @@ describe('App component', function() {
                 jest.doMock('chess-nlp', () => ({
                     __esModule: true,
                     default: jest.fn(() => ({
-                        toSAN: text => 'e4'
+                        textToSan: text => 'e4',
+                        sanToText: text => 'e4'
                     }))
                 }));
 
@@ -294,7 +308,12 @@ describe('App component', function() {
                 wrapper.find('.voice-command-button').simulate('click');
 
                 expect(wrapper).to.contain(<MoveHistoryTable moves={['e4']} />);
-                expect(wrapper).to.contain(<GameStatus status="Game over" />);
+                expect(wrapper).to.contain(
+                    <GameStatus
+                        display="Game over"
+                        announce="Game over"
+                    />
+                );
                 expect(wrapper).to.containMatchingElement(
                     <Chessboard position="foo" />
                 );
@@ -325,7 +344,12 @@ describe('App component', function() {
 
                 expect(mockReset).to.have.beenCalledTimes(1);
                 expect(wrapper).to.contain(<MoveHistoryTable moves={[]} />);
-                expect(wrapper).to.contain(<GameStatus status="Reset game"/>);
+                expect(wrapper).to.contain(
+                    <GameStatus
+                        display="Reset game"
+                        announce="Reset game"
+                    />
+                );
                 expect(wrapper).to.containMatchingElement(
                     <Chessboard position="foo" />
                 );
@@ -357,7 +381,10 @@ describe('App component', function() {
                 expect(mockUndo).to.have.beenCalledTimes(1);
                 expect(wrapper).to.contain(<MoveHistoryTable moves={[]} />);
                 expect(wrapper).to.contain(
-                    <GameStatus status="Undid last move"/>
+                    <GameStatus
+                        display="Undid last move"
+                        announce="Undid last move"
+                    />
                 );
                 expect(wrapper).to.containMatchingElement(
                     <Chessboard position="foo" />

--- a/frontend/src/components/GameStatus.js
+++ b/frontend/src/components/GameStatus.js
@@ -3,14 +3,15 @@ import PropTypes from 'prop-types';
 import { useSpeechSynthesis } from 'react-speech-kit';
 
 const propTypes = {
-    status: PropTypes.string
+    display: PropTypes.string,
+    announce: PropTypes.string
 };
 
 /**
  * Show the current status of the game (e.g. "Black to move", "Checkmate")
  * and say it out loud with text-to-speech.
  */
-const GameStatus = ({ status }) => {
+const GameStatus = ({ display, announce }) => {
     const { speak, voices } = useSpeechSynthesis();
     const voice = useMemo(() => {
         return voices.find(voice => voice.lang === 'en-US');
@@ -18,12 +19,12 @@ const GameStatus = ({ status }) => {
 
     // When status changes, say the new status out loud
     useEffect(() => {
-        if (status) speak({ text: status, voice });
-    }, [status]);
+        if (announce) speak({ text: announce, voice });
+    }, [announce]);
 
     return (
         <div className="game-status">
-            {status && <h2>{status}</h2>}
+            {display && <h2>{display}</h2>}
         </div>
     );
 };

--- a/frontend/src/components/GameStatus.spec.js
+++ b/frontend/src/components/GameStatus.spec.js
@@ -18,13 +18,13 @@ describe('GameStatus component', function() {
     beforeEach(() => jest.clearAllMocks());
 
     it('should show the current status', function() {
-        const wrapper = shallow(<GameStatus status="foo" />);
+        const wrapper = shallow(<GameStatus display="foo" />);
 
         expect(wrapper.find('.game-status')).to.have.text('foo');
     });
 
     it('should show nothing if status is not set', function() {
-        const wrapper = shallow(<GameStatus status={null} />);
+        const wrapper = shallow(<GameStatus display={null} />);
 
         expect(wrapper).to.be.empty;
     });
@@ -32,7 +32,7 @@ describe('GameStatus component', function() {
     it('should say the new status when status changes', function() {
         const wrapper = mount(<GameStatus />);
 
-        wrapper.setProps({ status: 'foo' });
+        wrapper.setProps({ announce: 'foo' });
 
         expect(mockSpeak).to.have.beenCalledWith({
             text: 'foo',
@@ -41,7 +41,7 @@ describe('GameStatus component', function() {
     });
 
     it('should say nothing when status becomes falsy', function() {
-        const wrapper = mount(<GameStatus status="foo" />);
+        const wrapper = mount(<GameStatus announce="foo" />);
 
         // mockSpeak is called once on initial render; clear the mock so we can
         // test if it's called again after changing the status prop


### PR DESCRIPTION
Moves were being announced in algebraic notation, so the speech
synthesis API would read e.g. "Rad4" as "rad four" instead of "rook a to
d4". Update it to read moves in natural English.