### PR TITLE
Announce both times when the same move is made twice in a row

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speech-to-chess",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "dependencies": {
     "bootstrap": "^4.5.0",

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -35,7 +35,7 @@ const parserOptions = {
         g: ['golf', 'gulf'],
         h: ['hotel', 'stage', 'age', 'its', 'each'],
         2: ['too'],
-        4: ['force', 'for', 'far', 'park', 'store', 'fork'],
+        4: ['force', 'for', 'far', 'park', 'store', 'fork', 'ford', 'fort'],
         5: ['v', 'psi'],
         6: ['sex'],
     }

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
 import { useSpeechRecognition } from 'react-speech-kit';
 import useChess from 'react-chess.js';
 import ChessNLP from 'chess-nlp';
@@ -46,14 +47,26 @@ const parser = new ChessNLP(parserOptions);
  * A chess game played with voice commands.
  */
 const App = (props) => {
+    const INITIAL_MOVE_NUMBER = 0;
     const [status, setStatus] = useState({});
+    const [moveNumber, setMoveNumber] = useState(INITIAL_MOVE_NUMBER);
     const [waitingForVoiceCommand, setWaitingForVoiceCommand] = useState(false);
     const voiceCommandTimeout = useRef(null);
     const stopListeningRef = useRef(null);
 
     const handleLegalMove = (move) => {
         const moveDesc = parser.sanToText(move);
-        setStatus({ display: `Moved ${move}`, announce: `Moved ${moveDesc}` });
+
+        // Use batched update to prevent GameStatus from re-rendering twice
+        // (once because of the change to moveNumber and once because of the
+        // change to status), which would cause duplicate announcements
+        ReactDOM.unstable_batchedUpdates(() => {
+            setMoveNumber(n => n + 1);
+            setStatus({
+                display: `Moved ${move}`,
+                announce: `Moved ${moveDesc}`
+            });
+        });
     };
 
     const handleIllegalMove = (move) => {
@@ -100,13 +113,23 @@ const App = (props) => {
         switch (command) {
             case 'undo':
                 undo();
-                status = 'Undid last move';
-                setStatus({ display: status, announce: status });
+
+                ReactDOM.unstable_batchedUpdates(() => {
+                    status = 'Undid last move';
+                    setMoveNumber(n => n - 1);
+                    setStatus({ display: status, announce: status });
+                });
+
                 return;
             case 'reset':
                 reset();
-                status = 'Reset game';
-                setStatus({ display: status, announce: status });
+
+                ReactDOM.unstable_batchedUpdates(() => {
+                    status = 'Reset game';
+                    setMoveNumber(INITIAL_MOVE_NUMBER);
+                    setStatus({ display: status, announce: status });
+                });
+
                 return;
             default:
                 let move;
@@ -189,7 +212,7 @@ const App = (props) => {
                     >
                         {listening ? 'Listening' : 'Click to give voice command'}
                     </Button>
-                    <GameStatus {...status} />
+                    <GameStatus moveNumber={moveNumber} {...status} />
                     <MoveHistoryTable moves={history} />
                 </Col>
             </Row>

--- a/frontend/src/components/GameStatus.js
+++ b/frontend/src/components/GameStatus.js
@@ -4,23 +4,24 @@ import { useSpeechSynthesis } from 'react-speech-kit';
 
 const propTypes = {
     display: PropTypes.string,
-    announce: PropTypes.string
+    announce: PropTypes.string,
+    moveNumber: PropTypes.number,
 };
 
 /**
  * Show the current status of the game (e.g. "Black to move", "Checkmate")
  * and say it out loud with text-to-speech.
  */
-const GameStatus = ({ display, announce }) => {
+const GameStatus = ({ display, announce, moveNumber }) => {
     const { speak, voices } = useSpeechSynthesis();
     const voice = useMemo(() => {
         return voices.find(voice => voice.lang === 'en-US');
     }, [voices]);
 
-    // When status changes, say the new status out loud
+    // When status or move number changes, say the new status out loud
     useEffect(() => {
         if (announce) speak({ text: announce, voice });
-    }, [announce]);
+    }, [announce, moveNumber]);
 
     return (
         <div className="game-status">

--- a/frontend/src/components/GameStatus.spec.js
+++ b/frontend/src/components/GameStatus.spec.js
@@ -52,4 +52,14 @@ describe('GameStatus component', function() {
         expect(mockSpeak).to.not.have.beenCalled();
     });
 
+    it('should say the status again when the move number changes', function() {
+        const wrapper = mount(<GameStatus moveNumber={1} announce="foo" />);
+
+        expect(mockSpeak).to.have.beenCalledTimes(1);
+
+        wrapper.setProps({ moveNumber: 2 });
+
+        expect(mockSpeak).to.have.beenCalledTimes(2);
+    });
+
 });


### PR DESCRIPTION
With pawns, it's common for the same exact move to be made twice in a row, e.g. "cxd4" (White's c3 pawn captures d4) followed by "cxd4" (Black's c5 pawn captures d4). There was a bug where only the first capture was being announced out loud. This pull request fixes the bug so both moves will be announced.